### PR TITLE
Make Armoire compatible with Rails2

### DIFF
--- a/lib/armoire.rb
+++ b/lib/armoire.rb
@@ -4,7 +4,8 @@ require 'erb'
 
 require "armoire/setting"
 require "armoire/version"
-require "armoire/railtie" if defined?(Rails)
+require "armoire/railtie" if defined?(Rails::Railtie)
+require "armoire/init" if defined?(Rails.configuration)
 
 class Armoire
   include Singleton

--- a/lib/armoire/init.rb
+++ b/lib/armoire/init.rb
@@ -1,0 +1,3 @@
+Rails.configuration.after_initialize do
+  Armoire.load! Rails.root.join('config', 'application.yml')
+end


### PR DESCRIPTION
Don't include the Railtie if it's in a rails 2 app.
