### PR TITLE
Allow environment to be set explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ Simply call `Armoire["foo"]` to get `"bar"` or `Armoire["nested_options"]["neste
 
 You may also call keys with any object that responds to `#to_s` and armoire will work correctly, e.g. `Armoire[:foo]`.
 
-The configuration environment will initially be taken from `ENV['RAILS_ENV']`, then `ENV['RACK_ENV']` and if neither exist then it will fall back to `development`
+The configuration environment will initially be taken from `ENV['RAILS_ENV']`, then `ENV['RACK_ENV']` and if neither exist then it will fall back to `development`.  Environment can also be set explicitly, but must be set prior to calling `load!`
+
+    Armoire.environment = 'not_rack'
 
 ### Usage in Rails
 

--- a/lib/armoire.rb
+++ b/lib/armoire.rb
@@ -15,10 +15,7 @@ class Armoire
   include Singleton
 
   attr_accessor :settings
-
-  def environment
-    ENV['RAILS_ENV'] || ENV['RACK_ENV'] || 'development'
-  end
+  attr_writer :environment
 
   def self.[](key)
     instance.settings[key]
@@ -26,6 +23,14 @@ class Armoire
 
   def self.load!(path_to_config_file)
     instance.settings = Setting.new(instance.load_settings(path_to_config_file))
+  end
+
+  def self.environment=(environment)
+    instance.environment = environment
+  end
+
+  def environment
+    @environment ||= ENV['RAILS_ENV'] || ENV['RACK_ENV'] || 'development'
   end
 
   def load_settings(path_to_config_file)

--- a/spec/lib/armoire_spec.rb
+++ b/spec/lib/armoire_spec.rb
@@ -4,6 +4,10 @@ describe Armoire do
   describe '#.environment' do
     subject { described_class.instance.environment }
 
+    before do
+      described_class.environment = nil
+    end
+
     context "ENV['RAILS_ENV'] is set" do
       before do
         @prev_rails_env = ENV['RAILS_ENV']
@@ -37,6 +41,27 @@ describe Armoire do
       end
     end
 
+    context "environment is explicitly set" do
+      before do
+        @prev_rails_env = ENV['RAILS_ENV']
+        @prev_rack_env = ENV['RACK_ENV']
+        ENV['RAILS_ENV'] = nil
+        ENV['RACK_ENV'] = nil
+        described_class.environment = 'no_rack'
+      end
+
+      it "returns the explicitly set environment" do
+        expect(subject).to eql("no_rack")
+      end
+
+      after do
+        ENV['RAILS_ENV'] = @prev_rails_env
+        ENV['RACK_ENV'] = @prev_rack_env
+        described_class.environment = nil
+      end
+    end
+
+
     context "nothing is set" do
       before do
         @prev_rails_env = ENV['RAILS_ENV']
@@ -53,6 +78,10 @@ describe Armoire do
         ENV['RAILS_ENV'] = @prev_rails_env
         ENV['RACK_ENV'] = @prev_rack_env
       end
+    end
+
+    after do
+      described_class.environment = nil
     end
   end
 


### PR DESCRIPTION
This change allows the environment to be set explicitly prior to load,
for applications where `RAILS_ENV` or `RACK_ENV` are not appropriate:

```
Armoire.environment = 'not_rack'
Armoire.load!('application.yml')
```
