### PR TITLE
Add fetch functionality to Armoire

### DIFF
--- a/lib/armoire.rb
+++ b/lib/armoire.rb
@@ -27,6 +27,10 @@ class Armoire
     instance.environment
   end
 
+  def self.fetch(key)
+    instance.settings.fetch(key)
+  end
+
   def environment
     @environment ||= ENV['RAILS_ENV'] || ENV['RACK_ENV'] || 'development'
   end

--- a/lib/armoire.rb
+++ b/lib/armoire.rb
@@ -27,10 +27,6 @@ class Armoire
     instance.environment
   end
 
-  def self.fetch(key)
-    instance.settings.fetch(key)
-  end
-
   def environment
     @environment ||= ENV['RAILS_ENV'] || ENV['RACK_ENV'] || 'development'
   end
@@ -46,6 +42,10 @@ class Armoire
 
   # When a config setting isn't set, this exception will be raised
   class ConfigSettingMissing < StandardError; end
+
+  class << self
+    alias fetch []
+  end
 end
 
 if defined?(Rails::Railtie)

--- a/lib/armoire/setting.rb
+++ b/lib/armoire/setting.rb
@@ -12,6 +12,8 @@ class Armoire
       value.kind_of?(Hash) ? self.class.new(value) : value
     end
 
+    alias fetch []
+
     private
     attr_reader :setting
   end

--- a/spec/lib/armoire/setting_spec.rb
+++ b/spec/lib/armoire/setting_spec.rb
@@ -41,4 +41,36 @@ describe Armoire::Setting do
       end
     end
   end
+
+  describe '#fetch' do
+    context 'setting is a value' do
+      subject { setting.fetch("simple") }
+
+      it 'returns the value' do
+        expect(subject).to eql("simple value")
+      end
+    end
+
+    context 'setting is a hash' do
+      subject { setting.fetch("nested") }
+
+      it 'returns a new setting object' do
+        expect(subject).to be_an_instance_of(described_class)
+      end
+    end
+
+    context 'it can be chained' do
+      subject { setting.fetch("nested").fetch("config") }
+      it 'returns the nested value' do
+        expect(subject).to eql("nested config value")
+      end
+    end
+
+    context 'missing key' do
+      subject { setting.fetch("missing_setting") }
+      it "raises an error" do
+        expect { subject }.to raise_error(Armoire::ConfigSettingMissing, '"missing_setting" is not set')
+      end
+    end
+  end
 end

--- a/spec/lib/armoire_spec.rb
+++ b/spec/lib/armoire_spec.rb
@@ -127,6 +127,48 @@ describe Armoire do
     end
   end
 
+  describe '#fetch' do
+    context "simple config option" do
+      subject { Armoire.fetch("simple_config_option") }
+
+      it { expect(subject).to eql("simple_config_option_value") }
+    end
+
+    context "referencing key via symbol instead of string" do
+      subject { Armoire.fetch(:simple_config_option) }
+
+      it { expect(subject).to eql("simple_config_option_value") }
+    end
+
+    context "erb config option" do
+      subject { Armoire.fetch("erb_config_option") }
+
+      it { expect(subject).to eql("erb_config_option_value") }
+    end
+
+    context "nested config option" do
+      subject { Armoire.fetch("nested").fetch("config").fetch("option") }
+
+      it { expect(subject).to eql("nested_config_option_value") }
+    end
+
+    context 'config setting is missing' do
+      subject { Armoire.fetch("missing_setting") }
+
+      it "raises an error" do
+        expect { subject }.to raise_error(Armoire::ConfigSettingMissing, '"missing_setting" is not set')
+      end
+    end
+
+    context 'nested config setting is missing' do
+      subject { Armoire.fetch("nested").fetch("config").fetch("missing_setting") }
+
+      it "raises an error" do
+        expect { subject }.to raise_error(Armoire::ConfigSettingMissing, '"missing_setting" is not set')
+      end
+    end
+  end
+
   describe '.load!' do
     context 'setting files exists' do
       before do


### PR DESCRIPTION
Previously, the fetch method was absent in Armoire, which prevented
users from obtaining a value from the settings hash, given a key, using
the fetch syntax.  Added a fetch method which returns the value, given a
key, from the Armoire settings.
