### PR TITLE
Add has_key? to settings

### DIFF
--- a/lib/armoire/setting.rb
+++ b/lib/armoire/setting.rb
@@ -12,6 +12,10 @@ class Armoire
       value.kind_of?(Hash) ? self.class.new(value) : value
     end
 
+    def has_key?(key)
+      setting.has_key?(key)
+    end
+
     private
     attr_reader :setting
   end

--- a/spec/lib/armoire/setting_spec.rb
+++ b/spec/lib/armoire/setting_spec.rb
@@ -41,4 +41,22 @@ describe Armoire::Setting do
       end
     end
   end
+
+  describe '#has_key?' do
+    subject { setting.has_key?(key) }
+    let(:key) { 'simple' }
+
+    it { is_expected.to eql true }
+
+    context 'missing key' do
+      let(:key) { 'key_not_present' }
+      it { is_expected.to eql false }
+    end
+
+    context 'nested key' do
+      let(:key) { 'config' }
+      it { is_expected.to eql false }
+    end
+
+  end
 end


### PR DESCRIPTION
Currently when we need to make a decision based on the presence of a configuration
key we have to attempt to access the key then rescue any `ConfigSettingMissing`
errors. It would be far simpler to call `.has_key?` as provided by `Hash` to evaluate the
setting.
